### PR TITLE
Add setup-go to static.yml

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,6 +26,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
       - name: Generate coverage and badge
         run: |
           ./ci/test.sh


### PR DESCRIPTION
The static deploy failed: https://github.com/coder/websocket/actions/runs/10408927491/job/28827386982, it seems to have Go even without setup-go, but most likely the `bin` directory for `go install`ed tools wasn't set up in `$PATH`.