### PR TITLE
Use the same DialOptions for WASM and non-WASM

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -20,36 +20,6 @@ import (
 	"github.com/coder/websocket/internal/errd"
 )
 
-// DialOptions represents Dial's options.
-type DialOptions struct {
-	// HTTPClient is used for the connection.
-	// Its Transport must return writable bodies for WebSocket handshakes.
-	// http.Transport does beginning with Go 1.12.
-	HTTPClient *http.Client
-
-	// HTTPHeader specifies the HTTP headers included in the handshake request.
-	HTTPHeader http.Header
-
-	// Host optionally overrides the Host HTTP header to send. If empty, the value
-	// of URL.Host will be used.
-	Host string
-
-	// Subprotocols lists the WebSocket subprotocols to negotiate with the server.
-	Subprotocols []string
-
-	// CompressionMode controls the compression mode.
-	// Defaults to CompressionDisabled.
-	//
-	// See docs on CompressionMode for details.
-	CompressionMode CompressionMode
-
-	// CompressionThreshold controls the minimum size of a message before compression is applied.
-	//
-	// Defaults to 512 bytes for CompressionNoContextTakeover and 128 bytes
-	// for CompressionContextTakeover.
-	CompressionThreshold int
-}
-
 func (opts *DialOptions) cloneWithDefaults(ctx context.Context) (context.Context, context.CancelFunc, *DialOptions) {
 	var cancel context.CancelFunc
 

--- a/ws.go
+++ b/ws.go
@@ -1,0 +1,36 @@
+package websocket // import "github.com/coder/websocket"
+
+import "net/http"
+
+// DialOptions represents Dial's options.
+//
+// Note that when building for WebAssembly, the following fields are ignored:
+// HTTPClient, HTTPHeader, Host, CompressionMode, CompressionThreshold.
+type DialOptions struct {
+	// HTTPClient is used for the connection.
+	// Its Transport must return writable bodies for WebSocket handshakes.
+	// http.Transport does beginning with Go 1.12.
+	HTTPClient *http.Client
+
+	// HTTPHeader specifies the HTTP headers included in the handshake request.
+	HTTPHeader http.Header
+
+	// Host optionally overrides the Host HTTP header to send. If empty, the value
+	// of URL.Host will be used.
+	Host string
+
+	// Subprotocols lists the WebSocket subprotocols to negotiate with the server.
+	Subprotocols []string
+
+	// CompressionMode controls the compression mode.
+	// Defaults to CompressionDisabled.
+	//
+	// See docs on CompressionMode for details.
+	CompressionMode CompressionMode
+
+	// CompressionThreshold controls the minimum size of a message before compression is applied.
+	//
+	// Defaults to 512 bytes for CompressionNoContextTakeover and 128 bytes
+	// for CompressionContextTakeover.
+	CompressionThreshold int
+}

--- a/ws_js.go
+++ b/ws_js.go
@@ -277,12 +277,6 @@ func (c *Conn) Subprotocol() string {
 	return c.ws.Subprotocol()
 }
 
-// DialOptions represents the options available to pass to Dial.
-type DialOptions struct {
-	// Subprotocols lists the subprotocols to negotiate with the server.
-	Subprotocols []string
-}
-
 // Dial creates a new WebSocket connection to the given url with the given options.
 // The passed context bounds the maximum time spent waiting for the connection to open.
 // The returned *http.Response is always nil or a mock. It's only in the signature


### PR DESCRIPTION
Partial fix for #373.  Although this won't actually change behavior, except that it will allow compiling the library for WASM, even when the caller doesn't use build tags to hide the non-WASM config variables (see https://github.com/coder/websocket/issues/373#issuecomment-2295347586).

Further follow-up to support these configuration features to the extent reasonable in the browser, or in non-browser WASM builds, may be desirable as follow-up.