### PR TITLE
hotfix: close received after close

### DIFF
--- a/close.go
+++ b/close.go
@@ -214,7 +214,7 @@ func (c *Conn) waitCloseHandshake() error {
 	}
 
 	for {
-		h, err := c.readLoop(ctx)
+		h, err := c.readLoop(ctx, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
waitCloseHandshake waits for client to respond with close frame but handleControl receives it and writes close again which may cause errors for some clients.

This is dump solution but it works in my case. I believe it can be done better, pls check it out.

Fixes: #448