### PR TITLE
fix: cancel netconn contexts after close handshake

### DIFF
--- a/netconn.go
+++ b/netconn.go
@@ -115,10 +115,12 @@ type netConn struct {
 var _ net.Conn = &netConn{}
 
 func (nc *netConn) Close() error {
-	nc.writeTimer.Stop()
-	nc.writeCancel()
-	nc.readTimer.Stop()
-	nc.readCancel()
+	defer func() {
+		nc.writeTimer.Stop()
+		nc.writeCancel()
+		nc.readTimer.Stop()
+		nc.readCancel()
+	}()
 	return nc.c.Close(StatusNormalClosure, "")
 }
 


### PR DESCRIPTION
This fixes a `failed to get reader: failed to read frame header: EOF` error we saw in `coder/coder` when upgrading to a version of the library where these contexts were cancelled during `netConn.Close`  (`>= v1.8.8`). 

This problem appears to happen when `netConn.c.Close(...)` is called *after* context cancellation causes `nc.c.close()` to be called (via `Conn.timeoutLoop`).

I *really* would've liked to fully understand why this problem was occurring on `coder/coder`, but following our usage of the library in the few testcases that this happens is incredibly difficult (as they're effectively fully end-to-end tests), and I was unable to produce an MRE for this bug despite my best efforts.