### PR TITLE
ws_js: return c.closeErr when closed during read

### DIFF
--- a/ws_js.go
+++ b/ws_js.go
@@ -158,6 +158,9 @@ func (c *Conn) read(ctx context.Context) (MessageType, []byte, error) {
 		return 0, nil, ctx.Err()
 	case <-c.readSignal:
 	case <-c.closed:
+		if c.closeErr != nil {
+			return 0, nil, c.closeErr
+		}
 		return 0, nil, net.ErrClosed
 	}
 


### PR DESCRIPTION
Return the close error when the WebSocket is closed (when running in WASM).

Previously, when the WebSocket connection is closed by the server, `Read` always returns `net.ErrClosed`, which prevents the correct handling of a close error with certain close status codes.

This might not be the best way to fix this, however we have been using this patch in production since June and it appears to resolve the issue and makes it possible to implement logic depending on the close code.