### PR TITLE
Fix build with Go 1.24

### DIFF
--- a/autobahn_test.go
+++ b/autobahn_test.go
@@ -92,7 +92,7 @@ func TestAutobahn(t *testing.T) {
 		}
 	})
 
-	c, _, err := websocket.Dial(ctx, fmt.Sprintf(wstestURL+"/updateReports?agent=main"), nil)
+	c, _, err := websocket.Dial(ctx, wstestURL+"/updateReports?agent=main", nil)
 	assert.Success(t, err)
 	c.Close(websocket.StatusNormalClosure, "")
 


### PR DESCRIPTION
Go 1.24 provides stricter checking that forbids passing a variable as a format string to Printf-like functions with no other arguments. Remove instances of this. See also:

https://tip.golang.org/doc/go1.24#vet