### PR TITLE
Add `WASM_NO_SANDBOX=on` to disable Chrome sandbox

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -24,7 +24,7 @@ cd -- "$(dirname "$0")/.."
 )
 
 
-go install github.com/agnivade/wasmbrowsertest@latest
+go install github.com/igolaizola/wasmbrowsertest@no-sandbox-env-test
 go test --race --bench=. --timeout=1h --covermode=atomic --coverprofile=ci/out/coverage.prof --coverpkg=./... "$@" ./...
 sed -i.bak '/stringer\.go/d' ci/out/coverage.prof
 sed -i.bak '/nhooyr.io\/websocket\/internal\/test/d' ci/out/coverage.prof

--- a/conn_test.go
+++ b/conn_test.go
@@ -365,7 +365,7 @@ func TestWasm(t *testing.T) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "test", "-exec=wasmbrowsertest", ".", "-v")
-	cmd.Env = append(cleanEnv(os.Environ()), "GOOS=js", "GOARCH=wasm", fmt.Sprintf("WS_ECHO_SERVER_URL=%v", s.URL))
+	cmd.Env = append(cleanEnv(os.Environ()), "GOOS=js", "GOARCH=wasm", fmt.Sprintf("WS_ECHO_SERVER_URL=%v", s.URL), "WASM_NO_SANDBOX=on")
 
 	b, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
The CI is currently failing with the following error message: "No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces..."

This commit updates the wasmbrowsertest to a version that supports the WASM_NO_SANDBOX environment variable, which disables the Chrome sandbox. Then it adds the environment variable to `TestWasm` in `conn_test.go`.