### PR TITLE
ci: disable AppArmor on daily and static workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,6 +19,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Disable AppArmor
+        if: runner.os == 'Linux'
+        run: |
+          # Disable AppArmor for Ubuntu 23.10+.
+          # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
@@ -41,6 +47,12 @@ jobs:
   test-dev:
     runs-on: ubuntu-latest
     steps:
+      - name: Disable AppArmor
+        if: runner.os == 'Linux'
+        run: |
+          # Disable AppArmor for Ubuntu 23.10+.
+          # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - uses: actions/checkout@v4
         with:
           ref: dev

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,6 +22,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      - name: Disable AppArmor
+        if: runner.os == 'Linux'
+        run: |
+          # Disable AppArmor for Ubuntu 23.10+.
+          # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages


### PR DESCRIPTION
AppArmor was disabled in CI workflows, but it was not disabled in the daily and static workflows.

References #512