### PR TITLE
ci: lock down staticcheck and govulncheck in lint.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           go-version-file: ./go.mod
       - run: ./ci/test.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage.html
           path: ./ci/out/coverage.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: go version
       - uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
       - run: ./ci/lint.sh
 
   test:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           go-version-file: ./go.mod
       - run: AUTOBAHN=1 ./ci/test.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage.html
           path: ./ci/out/coverage.html
@@ -60,7 +60,7 @@ jobs:
         with:
           go-version-file: ./go.mod
       - run: AUTOBAHN=1 ./ci/test.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-dev.html
           path: ./ci/out/coverage.html

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
+set -x
 set -eu
 cd -- "$(dirname "$0")/.."
 
 go vet ./...
 GOOS=js GOARCH=wasm go vet ./...
 
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
 staticcheck ./...
 GOOS=js GOARCH=wasm staticcheck ./...
 
@@ -15,7 +16,7 @@ govulncheck() {
 		cat "$tmpf"
 	fi
 }
-go install golang.org/x/vuln/cmd/govulncheck@latest
+go install golang.org/x/vuln/cmd/govulncheck@v1.1.1
 govulncheck ./...
 GOOS=js GOARCH=wasm govulncheck ./...
 


### PR DESCRIPTION
Required until we update from Go 1.19.