### PR TITLE
Use `context.AfterFunc()` instead of a goroutine to track timeouts

### DIFF
--- a/close.go
+++ b/close.go
@@ -231,12 +231,6 @@ func (c *Conn) waitGoroutines() error {
 	t := time.NewTimer(time.Second * 15)
 	defer t.Stop()
 
-	select {
-	case <-c.timeoutLoopDone:
-	case <-t.C:
-		return errors.New("failed to wait for timeoutLoop goroutine to exit")
-	}
-
 	c.closeReadMu.Lock()
 	closeRead := c.closeReadCtx != nil
 	c.closeReadMu.Unlock()

--- a/write.go
+++ b/write.go
@@ -271,14 +271,10 @@ func (c *Conn) writeFrame(ctx context.Context, fin bool, flate bool, opcode opco
 	select {
 	case <-c.closed:
 		return 0, net.ErrClosed
-	case c.writeTimeout <- ctx:
+	default:
 	}
-	defer func() {
-		select {
-		case <-c.closed:
-		case c.writeTimeout <- context.Background():
-		}
-	}()
+	c.setupWriteTimeout(ctx)
+	defer c.clearWriteTimeout()
 
 	c.writeHeader.fin = fin
 	c.writeHeader.opcode = opcode


### PR DESCRIPTION
This is a reworked version of https://github.com/coder/websocket/pull/501 with some minor improvements.

Closes https://github.com/coder/websocket/issues/411

Closes https://github.com/coder/websocket/pull/501