### PR TITLE
fix: match Origin scheme if defined in OriginPatterns

### DIFF
--- a/accept_test.go
+++ b/accept_test.go
@@ -466,6 +466,42 @@ func Test_authenticateOrigin(t *testing.T) {
 			},
 			success: false,
 		},
+		{
+			name:   "originPatternsWithSchemeHttps",
+			origin: "https://two.example.com",
+			host:   "example.com",
+			originPatterns: []string{
+				"https://*.example.com",
+			},
+			success: true,
+		},
+		{
+			name:   "originPatternsWithSchemeMismatch",
+			origin: "https://two.example.com",
+			host:   "example.com",
+			originPatterns: []string{
+				"http://*.example.com",
+			},
+			success: false,
+		},
+		{
+			name:   "originPatternsWithSchemeAndPort",
+			origin: "https://example.com:8443",
+			host:   "example.com",
+			originPatterns: []string{
+				"https://example.com:8443",
+			},
+			success: true,
+		},
+		{
+			name:   "backwardsCompatHostOnlyPattern",
+			origin: "http://two.example.com",
+			host:   "example.com",
+			originPatterns: []string{
+				"*.example.com",
+			},
+			success: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This change aligns origin checks with RFC 6454 by adding scheme-aware matching.

Fixes #529
